### PR TITLE
support retrieving all property values via ramda

### DIFF
--- a/src/create-type.js
+++ b/src/create-type.js
@@ -33,6 +33,10 @@ export const canonize = r.pipe(
 )
 
 const explodeOnUnknownProp = (obj, prop) => {
+  if (prop === '@@functional/placeholder') {
+    return
+  }
+
   if (prop in obj) {
     return obj[prop]
   }

--- a/src/create-type.test.js
+++ b/src/create-type.test.js
@@ -17,10 +17,23 @@ describe('KISS type', () => {
     })
     it('fails on attempted access to unknown props', () => {
       const failsNicely = __.throws(
-        __.typedError(TypeError, __.containsString('unknown'))
+        __.typedError(TypeError, __.containsString('Unknown'))
       )
       __.assertThat(() => type.get.unknown, failsNicely)
       __.assertThat(() => type.set.unknown, failsNicely)
+    })
+    it('all props can be retrieved with ramda', () => {
+      const doesNotThrow = __.not(
+        __.throws(
+          __.typedError(TypeError, __.containsString('Unknown'))
+        )
+      )
+      __.assertThat(() =>
+        r.pipe(
+          r.prop('props'),
+          r.values,
+        )(type)
+        , doesNotThrow)
     })
   })
 


### PR DESCRIPTION
This wasn't so much a problem with getting all properties but rather with the way getting all properties with ramda works and ramda internals. Ramda internaly checks to see if an argument is its internal placeholder thingy sometimes and to do that it looks to see if there is a property on the argument with the key "@@functional/placeholder". This of course invokes the get trap and the unknown property error is thrown.

Quick fix is just to check if the property being asked for is the placeholder property and if so just short circuit. It feels a bit strange to be doing ramda specific checks but at the same time given the
functional nature of kiss and type i don't think its too terrible :) 